### PR TITLE
Feature/runtime checks

### DIFF
--- a/src/main/java/com/apon/readableregex/IncorrectConstructionException.java
+++ b/src/main/java/com/apon/readableregex/IncorrectConstructionException.java
@@ -1,0 +1,10 @@
+package com.apon.readableregex;
+
+/**
+ * Exception that will be thrown when the builder methods are called in incorrect order or at the wrong time.
+ */
+public class IncorrectConstructionException extends RuntimeException {
+    public IncorrectConstructionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/apon/readableregex/QuantifierBuilder.java
+++ b/src/main/java/com/apon/readableregex/QuantifierBuilder.java
@@ -3,16 +3,16 @@ package com.apon.readableregex;
 /**
  * Builder interface with all the methods that adds quantifiers to standalone blocks.
  */
-public interface QuantifierBuilder extends StandaloneBlockBuilder {
+public interface QuantifierBuilder {
     /**
      * Makes the previous block repeat one or more times (greedy). This is the same as adding {@code +}.
      * @return This builder.
      */
-    StandaloneBlockBuilder oneOrMore();
+    ReadableRegex oneOrMore();
 
     /**
      * Makes the previous block optional (greedy). This is the same as adding {@code ?}.
      * @return This builder.
      */
-    StandaloneBlockBuilder optional();
+    ReadableRegex optional();
 }

--- a/src/main/java/com/apon/readableregex/ReadableRegex.java
+++ b/src/main/java/com/apon/readableregex/ReadableRegex.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  * {@link Pattern} objects, which creates {@link Matcher} objects. For additional functionality, the wrapper
  * {@link ReadableRegexPattern} can be created instead of {@link Pattern}.
  */
-public interface ReadableRegex extends StandaloneBlockBuilder {
+public interface ReadableRegex extends StandaloneBlockBuilder, QuantifierBuilder, FinishBuilder {
     /**
      * @return Instance of the builder.
      */

--- a/src/main/java/com/apon/readableregex/StandaloneBlockBuilder.java
+++ b/src/main/java/com/apon/readableregex/StandaloneBlockBuilder.java
@@ -6,7 +6,7 @@ package com.apon.readableregex;
  * {@code (?:\Qa.c\E)}. Incorrect is {@code ab}, since adding the optional quantifier {@code ?} for example, would make
  * the regex {@code ab?} which is different from {@code (?:ab)?}).
  */
-public interface StandaloneBlockBuilder extends FinishBuilder {
+public interface StandaloneBlockBuilder {
     /**
      * Appends the regex. The value is not changed or sanitized in any way.
      * <p>
@@ -15,24 +15,24 @@ public interface StandaloneBlockBuilder extends FinishBuilder {
      * @param regex The regular expression.
      * @return This builder.
      */
-    QuantifierBuilder regexFromString(String regex);
+    ReadableRegex regexFromString(String regex);
 
     /**
      * Appends a literal expression. All metacharacters are escaped.
      * @param literalValue The value to add.
      * @return This builder.
      */
-    QuantifierBuilder literal(String literalValue);
+    ReadableRegex literal(String literalValue);
 
     /**
      * Adds a digit. This is the same as {@code [0-9]}.
      * @return This builder.
      */
-    QuantifierBuilder digit();
+    ReadableRegex digit();
 
     /**
      * Adds a whitespace. This is the same as {@code \s}.
      * @return This builder.
      */
-    QuantifierBuilder whitespace();
+    ReadableRegex whitespace();
 }

--- a/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
+++ b/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
@@ -29,6 +29,7 @@ public class ReadableRegexImpl implements ReadableRegex {
 
     @Override
     public ReadableRegex literal(String literalValue) {
+        Objects.requireNonNull(literalValue);
         checkAndSetForStandaloneBlockExpression();
         // Surround input with \Q\E to make sure that all the meta characters are escaped.
         // Surround it with (?:) to make sure that

--- a/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
+++ b/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
@@ -1,5 +1,6 @@
 package com.apon.readableregex.internal;
 
+import com.apon.readableregex.IncorrectConstructionException;
 import com.apon.readableregex.ReadableRegex;
 import com.apon.readableregex.ReadableRegexPattern;
 
@@ -9,6 +10,9 @@ import java.util.regex.Pattern;
 public class ReadableRegexImpl implements ReadableRegex {
     /** The internal regular expression. This field should only be modified using the {@link #regexFromString(String)} method. */
     private final StringBuilder regexBuilder = new StringBuilder();
+
+    /** Indicates if the previous expression was a quantifier. Start with true, because you cannot start with a quantifier. */
+    private boolean previousExpressionWasQuantifier = true;
 
     @Override
     public ReadableRegexPattern build() {
@@ -25,6 +29,7 @@ public class ReadableRegexImpl implements ReadableRegex {
 
     @Override
     public ReadableRegex literal(String literalValue) {
+        checkAndSetForStandaloneBlockExpression();
         // Surround input with \Q\E to make sure that all the meta characters are escaped.
         // Surround it with (?:) to make sure that
         return regexFromString("(?:\\Q" + literalValue + "\\E)");
@@ -32,21 +37,43 @@ public class ReadableRegexImpl implements ReadableRegex {
 
     @Override
     public ReadableRegex digit() {
+        checkAndSetForStandaloneBlockExpression();
         return regexFromString("\\d");
     }
 
     @Override
     public ReadableRegex whitespace() {
+        checkAndSetForStandaloneBlockExpression();
         return regexFromString("\\s");
     }
 
     @Override
     public ReadableRegex oneOrMore() {
+        checkAndSetQuantifierExpression();
         return regexFromString("+");
     }
 
     @Override
     public ReadableRegex optional() {
+        checkAndSetQuantifierExpression();
         return regexFromString("?");
+    }
+
+    /**
+     * Do the needed checks for quantifier expression and indicate that the last executed expression is a quantifier expression.
+     */
+    private void checkAndSetQuantifierExpression() {
+        if (previousExpressionWasQuantifier) {
+            throw new IncorrectConstructionException("You cannot add a quantifier after a quantifier. Remove one of the incorrect quantifiers. " +
+                    "Or, if you haven't done anything yet, you started with a quantifier. That is not possible.");
+        }
+        previousExpressionWasQuantifier = true;
+    }
+
+    /**
+     * Do the needed checks for standalone block expression and indicate that the last executed expression is a standalone block expression.
+     */
+    private void checkAndSetForStandaloneBlockExpression() {
+        previousExpressionWasQuantifier = false;
     }
 }

--- a/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
+++ b/src/main/java/com/apon/readableregex/internal/ReadableRegexImpl.java
@@ -1,14 +1,12 @@
 package com.apon.readableregex.internal;
 
-import com.apon.readableregex.QuantifierBuilder;
 import com.apon.readableregex.ReadableRegex;
 import com.apon.readableregex.ReadableRegexPattern;
-import com.apon.readableregex.StandaloneBlockBuilder;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-public class ReadableRegexImpl implements ReadableRegex, QuantifierBuilder {
+public class ReadableRegexImpl implements ReadableRegex {
     /** The internal regular expression. This field should only be modified using the {@link #regexFromString(String)} method. */
     private final StringBuilder regexBuilder = new StringBuilder();
 
@@ -19,36 +17,36 @@ public class ReadableRegexImpl implements ReadableRegex, QuantifierBuilder {
     }
 
     @Override
-    public QuantifierBuilder regexFromString(String regex) {
+    public ReadableRegex regexFromString(String regex) {
         Objects.requireNonNull(regex);
         regexBuilder.append(regex);
         return this;
     }
 
     @Override
-    public QuantifierBuilder literal(String literalValue) {
+    public ReadableRegex literal(String literalValue) {
         // Surround input with \Q\E to make sure that all the meta characters are escaped.
         // Surround it with (?:) to make sure that
         return regexFromString("(?:\\Q" + literalValue + "\\E)");
     }
 
     @Override
-    public QuantifierBuilder digit() {
+    public ReadableRegex digit() {
         return regexFromString("\\d");
     }
 
     @Override
-    public QuantifierBuilder whitespace() {
+    public ReadableRegex whitespace() {
         return regexFromString("\\s");
     }
 
     @Override
-    public StandaloneBlockBuilder oneOrMore() {
+    public ReadableRegex oneOrMore() {
         return regexFromString("+");
     }
 
     @Override
-    public StandaloneBlockBuilder optional() {
+    public ReadableRegex optional() {
         return regexFromString("?");
     }
 }

--- a/src/test/java/com/apon/readableregex/FailConstructionTests.java
+++ b/src/test/java/com/apon/readableregex/FailConstructionTests.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static com.apon.readableregex.ReadableRegex.regex;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -16,14 +17,14 @@ class FailConstructionTests {
     class Quantifiers {
         @Test
         void cannotStartWithQuantifier() {
-            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().oneOrMore());
-            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().optional());
+            assertThrows(IncorrectConstructionException.class, () -> regex().oneOrMore());
+            assertThrows(IncorrectConstructionException.class, () -> regex().optional());
         }
 
         @Test
         void cannotUseQualifierAfterQualifier() {
-            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().digit().oneOrMore().optional());
-            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().digit().optional().oneOrMore());
+            assertThrows(IncorrectConstructionException.class, () -> regex().digit().oneOrMore().optional());
+            assertThrows(IncorrectConstructionException.class, () -> regex().digit().optional().oneOrMore());
         }
     }
 }

--- a/src/test/java/com/apon/readableregex/FailConstructionTests.java
+++ b/src/test/java/com/apon/readableregex/FailConstructionTests.java
@@ -1,0 +1,29 @@
+package com.apon.readableregex;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests related to constructions that are invalid and should throw an exception.
+ */
+@SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "@Nested classes should be non-static, but SpotBugs wants them static." +
+        "See https://github.com/spotbugs/spotbugs/issues/560 for the bug (open since 2018).")
+class FailConstructionTests {
+    @Nested
+    class Quantifiers {
+        @Test
+        void cannotStartWithQuantifier() {
+            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().oneOrMore());
+            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().optional());
+        }
+
+        @Test
+        void cannotUseQualifierAfterQualifier() {
+            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().digit().oneOrMore().optional());
+            assertThrows(IncorrectConstructionException.class, () -> ReadableRegex.regex().digit().optional().oneOrMore());
+        }
+    }
+}

--- a/src/test/java/com/apon/readableregex/FinishTests.java
+++ b/src/test/java/com/apon/readableregex/FinishTests.java
@@ -2,6 +2,7 @@ package com.apon.readableregex;
 
 import org.junit.jupiter.api.Test;
 
+import static com.apon.readableregex.ReadableRegex.regex;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class FinishTests {
     private final static String REGEX = "a1?";
-    private final ReadableRegex readableRegex = ReadableRegex.regex().regexFromString(REGEX);
+    private final ReadableRegex readableRegex = regex().regexFromString(REGEX);
 
     @Test
     void underlyingPatternIsExposed() {

--- a/src/test/java/com/apon/readableregex/FinishTests.java
+++ b/src/test/java/com/apon/readableregex/FinishTests.java
@@ -10,19 +10,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Tests related to methods that are inside {@link FinishBuilder}.
  */
 class FinishTests {
+    private final static String REGEX = "a1?";
+    private final ReadableRegex readableRegex = ReadableRegex.regex().regexFromString(REGEX);
+
     @Test
     void underlyingPatternIsExposed() {
-        assertThat(ReadableRegex.regex().buildJdkPattern().toString(), equalTo(""));
-        assertThat(ReadableRegex.regex().build().getUnderlyingPattern().toString(), equalTo(""));
+        assertThat(readableRegex.buildJdkPattern().toString(), equalTo(REGEX));
+        assertThat(readableRegex.build().getUnderlyingPattern().toString(), equalTo(REGEX));
     }
 
     @Test
     void toStringReturnsPattern() {
-        assertThat(ReadableRegex.regex().build().toString(), equalTo(""));
+        assertThat(readableRegex.build().toString(), equalTo(REGEX));
     }
 
     @Test
     void throwNpeWhenTextToMatchIsNull() {
-        assertThrows(NullPointerException.class, () -> ReadableRegex.regex().build().matches(null));
+        assertThrows(NullPointerException.class, () -> readableRegex.build().matches(null));
     }
 }

--- a/src/test/java/com/apon/readableregex/QuantifierTests.java
+++ b/src/test/java/com/apon/readableregex/QuantifierTests.java
@@ -3,6 +3,7 @@ package com.apon.readableregex;
 import org.junit.jupiter.api.Test;
 
 import static com.apon.readableregex.Constants.DIGITS;
+import static com.apon.readableregex.ReadableRegex.regex;
 import static com.apon.readableregex.matchers.PatternMatchMatcher.matchesExactly;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
@@ -13,7 +14,7 @@ import static org.hamcrest.Matchers.not;
 class QuantifierTests {
     @Test
     void oneOrMoreMatchesCorrectly() {
-        ReadableRegexPattern pattern = ReadableRegex.regex().digit().oneOrMore().build();
+        ReadableRegexPattern pattern = regex().digit().oneOrMore().build();
 
         assertThat(pattern, matchesExactly(DIGITS));
         assertThat(pattern, not(matchesExactly("")));
@@ -21,7 +22,7 @@ class QuantifierTests {
 
     @Test
     void optionalMatchesCorrectly() {
-        ReadableRegexPattern pattern = ReadableRegex.regex().literal("a").digit().optional().build();
+        ReadableRegexPattern pattern = regex().literal("a").digit().optional().build();
 
         assertThat(pattern, matchesExactly("a1"));
         assertThat(pattern, matchesExactly("a"));

--- a/src/test/java/com/apon/readableregex/StandaloneBlockTests.java
+++ b/src/test/java/com/apon/readableregex/StandaloneBlockTests.java
@@ -10,6 +10,7 @@ import static com.apon.readableregex.matchers.PatternMatchMatcher.doesntMatchAny
 import static com.apon.readableregex.matchers.PatternMatchMatcher.matchesExactly;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests related to methods that are inside {@link StandaloneBlockBuilder}.
@@ -43,6 +44,11 @@ class StandaloneBlockTests {
 
     @Nested
     class Literals {
+        @Test
+        void nullThrowsNpe() {
+            assertThrows(NullPointerException.class, () -> ReadableRegex.regex().literal(null));
+        }
+
         @Test
         void literalCharactersAreEscaped() {
             ReadableRegexPattern pattern = ReadableRegex.regex()

--- a/src/test/java/com/apon/readableregex/StandaloneBlockTests.java
+++ b/src/test/java/com/apon/readableregex/StandaloneBlockTests.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.apon.readableregex.Constants.*;
 import static com.apon.readableregex.Constants.WHITESPACES;
+import static com.apon.readableregex.ReadableRegex.regex;
 import static com.apon.readableregex.matchers.PatternMatchMatcher.doesntMatchAnythingFrom;
 import static com.apon.readableregex.matchers.PatternMatchMatcher.matchesExactly;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +23,7 @@ class StandaloneBlockTests {
     class Digits {
         @Test
         void digitOnlyMatchesDigits() {
-            ReadableRegexPattern pattern = ReadableRegex.regex().digit().build();
+            ReadableRegexPattern pattern = regex().digit().build();
 
             // Matches exactly every character inside DIGITS.
             for (String digit : DIGITS.split("")) {
@@ -35,7 +36,7 @@ class StandaloneBlockTests {
 
         @Test
         void digitsAreStandaloneBlocks() {
-            ReadableRegexPattern pattern = ReadableRegex.regex().literal("a").digit().oneOrMore().build();
+            ReadableRegexPattern pattern = regex().literal("a").digit().oneOrMore().build();
 
             assertThat(pattern, matchesExactly("a" + DIGITS));
             assertThat(pattern, not(matchesExactly("a1a1")));
@@ -46,12 +47,12 @@ class StandaloneBlockTests {
     class Literals {
         @Test
         void nullThrowsNpe() {
-            assertThrows(NullPointerException.class, () -> ReadableRegex.regex().literal(null));
+            assertThrows(NullPointerException.class, () -> regex().literal(null));
         }
 
         @Test
         void literalCharactersAreEscaped() {
-            ReadableRegexPattern pattern = ReadableRegex.regex()
+            ReadableRegexPattern pattern = regex()
                     .literal("a.()[]\\/|?.+*")
                     .build();
 
@@ -60,7 +61,7 @@ class StandaloneBlockTests {
 
         @Test
         void literalCanBeCombinedWithMetaCharacters() {
-            ReadableRegexPattern pattern = ReadableRegex.regex()
+            ReadableRegexPattern pattern = regex()
                     .literal(".").digit().whitespace().literal("*")
                     .build();
 
@@ -71,7 +72,7 @@ class StandaloneBlockTests {
 
         @Test
         void literalsAreStandaloneBlocks() {
-            ReadableRegexPattern pattern = ReadableRegex.regex().digit().literal("a").oneOrMore().build();
+            ReadableRegexPattern pattern = regex().digit().literal("a").oneOrMore().build();
 
             assertThat(pattern, matchesExactly("1aaaa"));
             assertThat(pattern, not(matchesExactly("1a1a")));
@@ -82,7 +83,7 @@ class StandaloneBlockTests {
     class Whitespaces {
         @Test
         void whitespacesOnlyMatchWhitespaces() {
-            ReadableRegexPattern pattern = ReadableRegex.regex().whitespace().build();
+            ReadableRegexPattern pattern = regex().whitespace().build();
 
             // Matches exactly every character inside WHITESPACES.
             for (String digit : WHITESPACES.split("")) {
@@ -96,7 +97,7 @@ class StandaloneBlockTests {
 
         @Test
         void whitespacesAreStandaloneBlocks() {
-            ReadableRegexPattern pattern = ReadableRegex.regex().literal("a").whitespace().oneOrMore().build();
+            ReadableRegexPattern pattern = regex().literal("a").whitespace().oneOrMore().build();
 
             assertThat(pattern, matchesExactly("a" + WHITESPACES));
             assertThat(pattern, not(matchesExactly("a a ")));


### PR DESCRIPTION
Throw exception when the builder is incorrectly used.

I wanted the object inheritance tree to force this during compile-time, but that made the library hard to work with.