### PR TITLE
Make spotbug annotations dependency only for test scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.spotbugs:spotbugs-annotations:4.1.1")
-
+    testImplementation("com.github.spotbugs:spotbugs-annotations:4.1.1")
     testImplementation("org.hamcrest:hamcrest:2.2")
 
     val junitVersion = "5.6.2"


### PR DESCRIPTION
The annotations are not used in production code. Only in test code we needed to suppress certain issues.