### PR TITLE
Feature/gradle refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     `java-library`
-    id("com.github.spotbugs") version "4.5.0"
     id("info.solidsoft.pitest") version "1.5.1"
 
     `my-checkstyle`
     `my-jacoco`
+    `my-spotbugs`
 
     `maven-publish`
     signing
@@ -29,7 +29,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation("com.github.spotbugs:spotbugs-annotations:4.1.1")
     testImplementation("org.hamcrest:hamcrest:2.2")
 
     val junitVersion = "5.6.2"
@@ -40,30 +39,6 @@ dependencies {
 
 val test by tasks.getting(Test::class) {
     useJUnitPlatform()
-}
-
-// ================
-// SpotBugs
-// ================
-spotbugs {
-    // Display final report as HTML.
-    // Use different HTML template (stylesheet) that is prettier.
-    tasks.spotbugsMain {
-        reports.create("html") {
-            isEnabled = true
-            setStylesheet("fancy-hist.xsl")
-        }
-    }
-    tasks.spotbugsTest {
-        reports.create("html") {
-            isEnabled = true
-            setStylesheet("fancy-hist.xsl")
-        }
-    }
-}
-tasks.register("spotbugs") {
-    dependsOn(tasks.spotbugsMain)
-    dependsOn(tasks.spotbugsTest)
 }
 
 // ================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,11 @@
 plugins {
     `java-library`
-
     `my-checkstyle`
     `my-jacoco`
     `my-spotbugs`
     `my-pitest`
     `my-test-percentage-printer`
-
-    `maven-publish`
-    signing
+    `my-artifact-publisher` apply false // We can only apply the plugin after the version has been determined.
 }
 
 group = "io.github.ricoapon"
@@ -17,6 +14,7 @@ version = when {
     else -> "head-SNAPSHOT"
 }
 println("Using version $version")
+plugins.apply("my-artifact-publisher")
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -40,69 +38,4 @@ dependencies {
 
 val test by tasks.getting(Test::class) {
     useJUnitPlatform()
-}
-
-// ================
-// Publishing artifacts to Maven Central
-// ================
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            artifactId = "readable-regex"
-            from(components["java"])
-            pom {
-                name.set("Readable Regex")
-                description.set("Regular expressions made readable in Java")
-                url.set("https://github.com/ricoapon/readable-regex")
-                inceptionYear.set("2020")
-
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://github.com/ricoapon/readable-regex/blob/master/LICENSE")
-                    }
-                }
-
-                developers {
-                    developer {
-                        id.set("ricoapon")
-                        name.set("Rico Apon")
-                    }
-                }
-
-                scm {
-                    url.set("https://github.com/ricoapon/readable-regex")
-                    connection.set("scm:https://github.com/ricoapon/readable-regex.git")
-                    developerConnection.set("scm:git@github.com:ricoapon/readable-regex.git")
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-
-            credentials {
-                username = project.findProperty("ossrhUsername") as String?
-                password = project.findProperty("ossrhPassword") as String?
-            }
-        }
-    }
-}
-signing {
-    sign(publishing.publications["mavenJava"])
-}
-tasks.javadoc {
-    if (JavaVersion.current().isJava9Compatible) {
-        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    }
-}
-
-// Make sure that we can only publish if all checks have been completed successfully.
-// Don't add this to the task "publish", because this can go wrong with parallel execution.
-tasks.withType<PublishToMavenRepository> {
-    dependsOn("check")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
     `java-library`
     id("com.github.spotbugs") version "4.5.0"
-    id("checkstyle")
     id("jacoco")
     id("info.solidsoft.pitest") version "1.5.1"
+    `my-checkstyle`
     `maven-publish`
     signing
 }
@@ -62,17 +62,6 @@ spotbugs {
 tasks.register("spotbugs") {
     dependsOn(tasks.spotbugsMain)
     dependsOn(tasks.spotbugsTest)
-}
-
-// ================
-// Checkstyle
-// ================
-tasks.withType<Checkstyle>().configureEach {
-    configFile = File("checkstyle.xml")
-}
-tasks.register("checkstyle") {
-    dependsOn(tasks.checkstyleMain)
-    dependsOn(tasks.checkstyleTest)
 }
 
 // ================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `my-jacoco`
     `my-spotbugs`
     `my-pitest`
+    `my-test-percentage-printer`
 
     `maven-publish`
     signing
@@ -39,55 +40,6 @@ dependencies {
 
 val test by tasks.getting(Test::class) {
     useJUnitPlatform()
-}
-
-// ================
-// Print test percentages
-// ================
-tasks.register("printTestPercentages") {
-    // Don't add the input files to the task. The percentages should always show, also if the task has already been executed.
-    doLast {
-        printTestPercentages()
-    }
-    dependsOn("jacoco", "pitest")
-}
-tasks.check {
-    finalizedBy("printTestPercentages")
-}
-
-fun printTestPercentages() {
-    var resultString = "Coverage Summary:\n"
-    readTestPercentageFromJacocoReport().forEach { resultString += createLine(it) }
-    readTestPercentagesFromPitestReport().forEach { resultString += createLine(it) }
-    println(resultString)
-}
-
-fun createLine(result: Map.Entry<String, Pair<Int, Int>>): String =
-        "${result.key.padEnd(18)}: ${Math.floorDiv(result.value.first * 100, result.value.second).toString().padStart(3)}% " +
-                "(${result.value.first.toString().padStart(4)} / ${result.value.second.toString().padStart(4)})\n"
-
-fun readTestPercentageFromJacocoReport(): Map<String, Pair<Int, Int>> {
-    val reportFileContent = File(project.buildDir.resolve("reports/jacoco/test/jacocoTestReport.xml").toURI()).readText()
-
-    val pattern = Regex("<\\/package><counter type=\"INSTRUCTION\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>" +
-            "<counter type=\"BRANCH\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>" +
-            "<counter type=\"LINE\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>")
-    val (instructionMissed, instructionTotal, branchMissed, branchTotal, lineMissed, lineTotal) = pattern.find(reportFileContent)!!.destructured
-
-    return mapOf("JACOCO_INSTRUCTION" to Pair(Integer.parseInt(instructionTotal) - Integer.parseInt(instructionMissed), Integer.parseInt(instructionTotal)),
-            "JACOCO_BRANCH" to Pair(Integer.parseInt(branchTotal) - Integer.parseInt(branchMissed), Integer.parseInt(branchTotal)),
-            "JACOCO_LINE" to Pair(Integer.parseInt(lineTotal) - Integer.parseInt(lineMissed), Integer.parseInt(lineTotal)))
-}
-
-fun readTestPercentagesFromPitestReport(): Map<String, Pair<Int, Int>> {
-    val reportFileContent = File(project.buildDir.resolve("reports/pitest/index.html").toURI()).readText()
-
-    val pattern = Regex("<td>\\d+% <div class=\"coverage_bar\"><div class=\"coverage_complete width-\\d+\"></div><div class=\"coverage_legend\">(\\d+)/(\\d+)</div></div></td>.*\\r?\\n?" +
-            "\\s+<td>\\d+% <div class=\"coverage_bar\"><div class=\"coverage_complete width-\\d+\"></div><div class=\"coverage_legend\">(\\d+)/(\\d+)</div></div></td>")
-    val (lineCoverageHit, lineCoverageTotal, mutationCoverageHit, mutationCoverageTotal) = pattern.find(reportFileContent)!!.destructured
-
-    return mapOf("PITEST_LINE" to Pair(Integer.parseInt(lineCoverageHit), Integer.parseInt(lineCoverageTotal)),
-            "PITEST_MUTATION" to Pair(Integer.parseInt(mutationCoverageHit), Integer.parseInt(mutationCoverageTotal)))
 }
 
 // ================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     `java-library`
     id("com.github.spotbugs") version "4.5.0"
-    id("jacoco")
     id("info.solidsoft.pitest") version "1.5.1"
+
     `my-checkstyle`
+    `my-jacoco`
+
     `maven-publish`
     signing
 }
@@ -62,36 +64,6 @@ spotbugs {
 tasks.register("spotbugs") {
     dependsOn(tasks.spotbugsMain)
     dependsOn(tasks.spotbugsTest)
-}
-
-// ================
-// JaCoCo
-// ================
-jacoco {
-    // Experimental support for Java 15 has only been added to 0.8.6.
-    // Release version 0.8.7 will officially support Java 15.
-    toolVersion = "0.8.6"
-}
-tasks.check {
-    // Reports are always generated after running the checks.
-    finalizedBy(tasks.jacocoTestReport)
-}
-tasks.jacocoTestReport {
-    // Tests are required before generating the report.
-    dependsOn(tasks.test)
-}
-tasks.jacocoTestReport {
-    reports {
-        // Codecov.io depends on xml format report.
-        xml.isEnabled = true
-        // Add HTML report readable by humans.
-        html.isEnabled = true
-    }
-}
-
-tasks.register("jacoco") {
-    dependsOn(tasks.jacocoTestCoverageVerification)
-    dependsOn(tasks.jacocoTestReport)
 }
 
 // ================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     `java-library`
-    id("info.solidsoft.pitest") version "1.5.1"
 
     `my-checkstyle`
     `my-jacoco`
     `my-spotbugs`
+    `my-pitest`
 
     `maven-publish`
     signing
@@ -39,19 +39,6 @@ dependencies {
 
 val test by tasks.getting(Test::class) {
     useJUnitPlatform()
-}
-
-// ================
-// Pitest
-// ================
-pitest {
-    junit5PluginVersion.set("0.12")
-    outputFormats.set(listOf("HTML"))
-    timestampedReports.set(false)
-    threads.set(4)
-}
-tasks.check {
-    finalizedBy(tasks.pitest)
 }
 
 // ================

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,13 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    gradlePluginPortal()
 }
+
+// External plugins cannot be included with a version inside the standalone scripts. Therefore we need to add them as
+// a dependency inside this build script in a specific way.
+dependencies {
+    implementation(plugin("com.github.spotbugs", "4.5.0"))
+}
+
+fun plugin(id: String, version: String) = "$id:$id.gradle.plugin:$version"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 // a dependency inside this build script in a specific way.
 dependencies {
     implementation(plugin("com.github.spotbugs", "4.5.0"))
+    implementation(plugin("info.solidsoft.pitest", "1.5.1"))
 }
 
 fun plugin(id: String, version: String) = "$id:$id.gradle.plugin:$version"

--- a/buildSrc/src/main/kotlin/my-artifact-publisher.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-artifact-publisher.gradle.kts
@@ -1,0 +1,75 @@
+import org.gradle.kotlin.dsl.*
+
+/**
+ * This file contains all the build logic related to publishing artifacts to Maven Central.
+ * This plugin should only be applied after the version of the project has been determined.
+ */
+plugins {
+    java
+    `maven-publish`
+    signing
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            artifactId = "readable-regex"
+            from(components["java"])
+            pom {
+                name.set("Readable Regex")
+                description.set("Regular expressions made readable in Java")
+                url.set("https://github.com/ricoapon/readable-regex")
+                inceptionYear.set("2020")
+
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://github.com/ricoapon/readable-regex/blob/master/LICENSE")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("ricoapon")
+                        name.set("Rico Apon")
+                    }
+                }
+
+                scm {
+                    url.set("https://github.com/ricoapon/readable-regex")
+                    connection.set("scm:https://github.com/ricoapon/readable-regex.git")
+                    developerConnection.set("scm:git@github.com:ricoapon/readable-regex.git")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+
+            credentials {
+                username = project.findProperty("ossrhUsername") as String?
+                password = project.findProperty("ossrhPassword") as String?
+            }
+        }
+    }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
+}
+
+tasks.javadoc {
+    if (JavaVersion.current().isJava9Compatible) {
+        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    }
+}
+
+// Make sure that we can only publish if all checks have been completed successfully.
+// Don't add this to the task "publish", because this can go wrong with parallel execution.
+tasks.withType<PublishToMavenRepository> {
+    dependsOn("check")
+}

--- a/buildSrc/src/main/kotlin/my-checkstyle.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-checkstyle.gradle.kts
@@ -1,0 +1,18 @@
+/**
+ * This file contains the logic to configure checkstyle.
+ */
+plugins {
+    java
+    checkstyle
+}
+
+tasks.withType<Checkstyle>().configureEach {
+    configFile = File("checkstyle.xml")
+}
+tasks.register("checkstyle") {
+    dependsOn(tasks.checkstyleMain)
+    dependsOn(tasks.checkstyleTest)
+}
+
+// Checkstyle automatically adds the checkstyleMain and checkstyleTest to the check task.
+// We don't need to do this ourselves.

--- a/buildSrc/src/main/kotlin/my-jacoco.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-jacoco.gradle.kts
@@ -1,0 +1,35 @@
+/**
+ * This file contains the logic to configure jacoco.
+ */
+plugins {
+    java
+    jacoco
+}
+
+jacoco {
+    // Experimental support for Java 15 has only been added to 0.8.6. Release version 0.8.7 will officially support Java 15.
+    // This needs to be set, otherwise this task won't run properly if you use Java 15+ locally.
+    toolVersion = "0.8.6"
+}
+
+tasks.jacocoTestReport {
+    // Tests are required before generating the report. For some reason, you need to do this yourself.
+    dependsOn(tasks.test)
+
+    reports {
+        // Codecov.io depends on xml format report.
+        xml.isEnabled = true
+        // Add HTML report readable by humans.
+        html.isEnabled = true
+    }
+}
+
+tasks.register("jacoco") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+    dependsOn(tasks.jacocoTestReport)
+}
+
+tasks.check {
+    // Reports are always generated after running the checks.
+    finalizedBy(tasks.jacocoTestReport)
+}

--- a/buildSrc/src/main/kotlin/my-pitest.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-pitest.gradle.kts
@@ -1,0 +1,18 @@
+/**
+ * This file contains the logic to configure pitest.
+ */
+plugins {
+    java
+    id("info.solidsoft.pitest")
+}
+
+pitest {
+    junit5PluginVersion.set("0.12")
+    outputFormats.set(listOf("HTML"))
+    timestampedReports.set(false)
+    threads.set(4)
+}
+
+tasks.check {
+    dependsOn(tasks.pitest)
+}

--- a/buildSrc/src/main/kotlin/my-spotbugs.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-spotbugs.gradle.kts
@@ -1,0 +1,39 @@
+/**
+ * This file contains the logic to configure spotbugs.
+ */
+plugins {
+    java
+    id("com.github.spotbugs")
+}
+
+dependencies {
+    // The spotbugs annotation dependency may not occur as dependency. It is only needed at compile time.
+    // Annotations are currently not used in production code. If this should be the case in the future, add the dependency
+    // as compileOnly.
+    testCompileOnly("com.github.spotbugs:spotbugs-annotations:4.1.1")
+}
+
+spotbugs {
+    // Display final report as HTML.
+    // Use different HTML template (stylesheet) that is prettier.
+    tasks.spotbugsMain {
+        reports.create("html") {
+            isEnabled = true
+            setStylesheet("fancy-hist.xsl")
+        }
+    }
+    tasks.spotbugsTest {
+        reports.create("html") {
+            isEnabled = true
+            setStylesheet("fancy-hist.xsl")
+        }
+    }
+}
+
+tasks.register("spotbugs") {
+    dependsOn(tasks.spotbugsMain)
+    dependsOn(tasks.spotbugsTest)
+}
+
+// Spotbugs automatically adds the spotbugsMain and spotbugsTest to the check task.
+// We don't need to do this ourselves.

--- a/buildSrc/src/main/kotlin/my-test-percentage-printer.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-test-percentage-printer.gradle.kts
@@ -22,7 +22,7 @@ fun printTestPercentages() {
     var resultString = "Coverage Summary:\n"
     readTestPercentageFromJacocoReport().forEach { resultString += createLine(it) }
     readTestPercentagesFromPitestReport().forEach { resultString += createLine(it) }
-    println(resultString)
+    print(resultString)
 }
 
 fun createLine(result: Map.Entry<String, Pair<Int, Int>>): String =

--- a/buildSrc/src/main/kotlin/my-test-percentage-printer.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-test-percentage-printer.gradle.kts
@@ -1,0 +1,54 @@
+/**
+ * This file adds the logic for printing test percentages from reports to the console. It is assumed that the jacoco
+ * and pitest plugins are applied.
+ */
+plugins {
+    java
+}
+
+tasks.register("printTestPercentages") {
+    // Don't add the input files to the task. The percentages should always show, also if the task has already been executed.
+    doLast {
+        printTestPercentages()
+    }
+    dependsOn("jacoco", "pitest")
+}
+
+tasks.check {
+    finalizedBy("printTestPercentages")
+}
+
+fun printTestPercentages() {
+    var resultString = "Coverage Summary:\n"
+    readTestPercentageFromJacocoReport().forEach { resultString += createLine(it) }
+    readTestPercentagesFromPitestReport().forEach { resultString += createLine(it) }
+    println(resultString)
+}
+
+fun createLine(result: Map.Entry<String, Pair<Int, Int>>): String =
+        "${result.key.padEnd(18)}: ${Math.floorDiv(result.value.first * 100, result.value.second).toString().padStart(3)}% " +
+                "(${result.value.first.toString().padStart(4)} / ${result.value.second.toString().padStart(4)})\n"
+
+fun readTestPercentageFromJacocoReport(): Map<String, Pair<Int, Int>> {
+    val reportFileContent = File(project.buildDir.resolve("reports/jacoco/test/jacocoTestReport.xml").toURI()).readText()
+
+    val pattern = Regex("<\\/package><counter type=\"INSTRUCTION\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>" +
+            "<counter type=\"BRANCH\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>" +
+            "<counter type=\"LINE\" missed=\"(\\d+)\" covered=\"(\\d+)\"\\/>")
+    val (instructionMissed, instructionTotal, branchMissed, branchTotal, lineMissed, lineTotal) = pattern.find(reportFileContent)!!.destructured
+
+    return mapOf("JACOCO_INSTRUCTION" to Pair(Integer.parseInt(instructionTotal) - Integer.parseInt(instructionMissed), Integer.parseInt(instructionTotal)),
+            "JACOCO_BRANCH" to Pair(Integer.parseInt(branchTotal) - Integer.parseInt(branchMissed), Integer.parseInt(branchTotal)),
+            "JACOCO_LINE" to Pair(Integer.parseInt(lineTotal) - Integer.parseInt(lineMissed), Integer.parseInt(lineTotal)))
+}
+
+fun readTestPercentagesFromPitestReport(): Map<String, Pair<Int, Int>> {
+    val reportFileContent = File(project.buildDir.resolve("reports/pitest/index.html").toURI()).readText()
+
+    val pattern = Regex("<td>\\d+% <div class=\"coverage_bar\"><div class=\"coverage_complete width-\\d+\"></div><div class=\"coverage_legend\">(\\d+)/(\\d+)</div></div></td>.*\\r?\\n?" +
+            "\\s+<td>\\d+% <div class=\"coverage_bar\"><div class=\"coverage_complete width-\\d+\"></div><div class=\"coverage_legend\">(\\d+)/(\\d+)</div></div></td>")
+    val (lineCoverageHit, lineCoverageTotal, mutationCoverageHit, mutationCoverageTotal) = pattern.find(reportFileContent)!!.destructured
+
+    return mapOf("PITEST_LINE" to Pair(Integer.parseInt(lineCoverageHit), Integer.parseInt(lineCoverageTotal)),
+            "PITEST_MUTATION" to Pair(Integer.parseInt(mutationCoverageHit), Integer.parseInt(mutationCoverageTotal)))
+}


### PR DESCRIPTION
Refactor parts of the gradle build script into separate scripts inside buildSrc.

This makes the gradle build file more readable for users that only use the project. It is now easier to see:
- Which dependencies are used.
- Which java version is used.
- Which artifacts are uploaded to artifactory
- What is the groupId.

It is now also easier to maintain, since each of the functionalities is in a separate file. It is very clear what is applied to the project and how. By putting it in separate files, it is also easier to copy for me in other projects :)